### PR TITLE
Adding an console out when tweet it's filtered

### DIFF
--- a/cmd/tweet-bot-r/main.go
+++ b/cmd/tweet-bot-r/main.go
@@ -165,7 +165,11 @@ func main() {
         //  and quoted tweets without the hashtag
         if ( tweet.User.ScreenName == user.ScreenName ||
              tweet.RetweetedStatus != nil ||
-             !strings.Contains(strings.ToLower(tweet.Text), strings.ToLower(hashtag))) { return }
+             !strings.Contains(strings.ToLower(tweet.Text), strings.ToLower(hashtag))) { 
+                log.Printf("WARN Filtered tweet with text: %s\n",tweet.Text)
+                log.Println("-----------------")
+                return 
+            }
 
         // Received tweet info
         log.Printf("Tweet ID: %d\n", tweet.ID)


### PR DESCRIPTION
# What does this pull request do?
Now when a tweet it's filtered out for not meeting the condition, it'll still be logged in the output console.

# How should it be tested?

Just logging this time.